### PR TITLE
use keyvault name instead of id and allow to have separate keys for web an pubsub

### DIFF
--- a/ocpp-server/.gitignore
+++ b/ocpp-server/.gitignore
@@ -397,3 +397,4 @@ FodyWeavers.xsd
 *.sln.iml
 
 *parameters.json
+*parameters.bicepparam

--- a/ocpp-server/Makefile
+++ b/ocpp-server/Makefile
@@ -1,9 +1,11 @@
 THIS_FILE := $(lastword $(MAKEFILE_LIST))
 RG_NAME := OCPP
 RG_LOCATION := switzerlandnorth
+BICEP_PARAMS := main.parameters.bicepparam
 WEBAPP_NAME := $(shell az webapp list -g $(RG_NAME) --query "[0].name" -o tsv)
 STORAGE_NAME := $(shell az storage account list -g $(RG_NAME) --query "[?starts_with(name,'webdeploy')].name" -o tsv)
 EXPIRY := $(shell date -u -d "15 minutes" '+%Y-%m-%dT%H:%MZ')
+TEST_SERVER := wss.jmservera.online
 
 preparecli:
 	az upgrade
@@ -11,18 +13,22 @@ preparecli:
 	az bicep upgrade
 	npm install -g @azure/web-pubsub-tunnel-tool
 	@echo "Tools prepared, now you can start using the makefile"
-build: $(wildcard api/**/*.cs)
-	@echo "Building"
+build: build-api build-node
+build-node: $(wildcard client/*.js)
+	@echo "Building node client"
+	cd client && npm install
+build-api: $(wildcard api/**/*.cs)
+	@echo "Building api"
 	dotnet build api/api.sln
 test:
 	@echo "Testing"
 	dotnet test api/api.sln
 test-client:
 	@echo "Testing a simple node client"
-	node client/index.js wss://wss.jmservera.online station2 goodpwd
+	node client/index.js wss://$(TEST_SERVER) station2 goodpwd
 test-client-badauth:
 	@echo "Testing a simple node client"
-	node client/index.js wss://wss.jmservera.online station1 badpwd
+	node client/index.js wss://$(TEST_SERVER) station1 badpwd
 clean:
 	@echo "Cleaning"
 	dotnet clean api/api.sln
@@ -41,10 +47,10 @@ start-tunnel:
 	awps-tunnel run --hub OcppService -c "$$WebPubSubConnectionString" -s $$SubId -g $(RG_NAME) --upstream http://localhost:5110
 stop-tunnel:
 	ps axf | grep awps-tunnel | grep -v grep | awk '{print "kill -9 " $$1}' | sh
-infra: $(wildcard infra/**/*.bicep) $(wildcard infra/**/*.parameters.json)
+infra: $(wildcard infra/**/*.bicep) $(wildcard infra/*.parameters.bicepparam)
 	@echo "Deploying infra to Azure"
 	az group create -n $(RG_NAME) -l $(RG_LOCATION)
-	az deployment group create -g $(RG_NAME) --template-file infra/main.bicep --parameters infra/main.parameters.json
+	az deployment group create -g $(RG_NAME) --template-file infra/main.bicep --parameters infra/$(BICEP_PARAMS)
 	@echo "Setting up user secrets"
 	CONNECTION_STRING='$(shell az webpubsub list -g $(RG_NAME) --query "[0].name" -o tsv | az webpubsub key show -g $(RG_NAME) -n @- --query "primaryConnectionString" -o tsv)'; \
 	dotnet user-secrets set 'WEBPUBSUB_SERVICE_CONNECTION_STRING' "$$CONNECTION_STRING" --project api/OcppServer/OcppServer.csproj	
@@ -67,4 +73,4 @@ deploy:
 	@echo "Waiting for infra to be ready"
 	sleep 60 
 	@$(MAKE) -f $(THIS_FILE) publish
-.PHONY: test clean watch start secrets test-client
+.PHONY: test clean watch start secrets test-client infra

--- a/ocpp-server/infra/main.parameters.bicepparam.example
+++ b/ocpp-server/infra/main.parameters.bicepparam.example
@@ -1,0 +1,9 @@
+using 'main.bicep'
+
+param pubsubKeyVaultCertName = '<KeyVault name of the SSL Certificate for the pub sub service>'
+param webKeyVaultCertName ='<KeyVault name of the SSL Certificate for the web test service, can be the same cert if you have a wildcard one>'
+param keyVaultName = '<Name of the KeyVault>'
+param keyVaultIdentityRG ='<NAME OF THE Managed Identity that has cert read access rights in the KeyVault>'
+param customDnsZoneName ='<RESOURCE GROUP OF THE MANAGED IDENTITY>'
+param pubsubARecordName ='<SUBDOMAIN NAME USED FOR THE WEB PUBSUB SERVICE, EX: wss (for wss.mydomain.com)>'
+param dnsZoneRG ='<NAME OF THE RG WHERE THE DNS SERVICE>'


### PR DESCRIPTION
This pull request includes several changes to the `ocpp-server` project, focusing on updating deployment configurations, improving the Makefile, and enhancing the documentation. The most important changes include the addition of new parameters for Bicep files, updates to the Makefile to support new build and test commands, and modifications to the README to reflect these updates.

### Deployment Configuration Updates:

* [`ocpp-server/infra/main.bicep`](diffhunk://#diff-5834392e88c0addb6d4022e20a4d4b3826f9c48f7c09f18e53118462740f6053L2-R19): Added new parameters for `pubsubKeyVaultCertName`, `webKeyVaultCertName`, and `keyVaultName` to improve certificate management. Updated module references to use these new parameters. [[1]](diffhunk://#diff-5834392e88c0addb6d4022e20a4d4b3826f9c48f7c09f18e53118462740f6053L2-R19) [[2]](diffhunk://#diff-5834392e88c0addb6d4022e20a4d4b3826f9c48f7c09f18e53118462740f6053L42-R46) [[3]](diffhunk://#diff-5834392e88c0addb6d4022e20a4d4b3826f9c48f7c09f18e53118462740f6053L90-R98) [[4]](diffhunk://#diff-5834392e88c0addb6d4022e20a4d4b3826f9c48f7c09f18e53118462740f6053L101-R107)
* [`ocpp-server/infra/modules/appgw.bicep`](diffhunk://#diff-e03afb5e606f0ebada0f58abf8b0d88351e44e208dc2123225a6d294de2efc26L14-R22): Added new parameters and resources for handling KeyVault certificates, including logic to handle wildcard certificates. [[1]](diffhunk://#diff-e03afb5e606f0ebada0f58abf8b0d88351e44e208dc2123225a6d294de2efc26L14-R22) [[2]](diffhunk://#diff-e03afb5e606f0ebada0f58abf8b0d88351e44e208dc2123225a6d294de2efc26R32-R50) [[3]](diffhunk://#diff-e03afb5e606f0ebada0f58abf8b0d88351e44e208dc2123225a6d294de2efc26L170-R210) [[4]](diffhunk://#diff-e03afb5e606f0ebada0f58abf8b0d88351e44e208dc2123225a6d294de2efc26L194-R230)

### Makefile Improvements:

* [`ocpp-server/Makefile`](diffhunk://#diff-1423f21b09a0edce66dbaf1b78a9c2647b29085693a34e9d4d51c393b6505628R4-R31): Introduced new variables `BICEP_PARAMS` and `TEST_SERVER`. Added new build targets `build-node` and `build-api` for separate client and API builds. Updated test commands to use the `TEST_SERVER` variable.
* [`ocpp-server/Makefile`](diffhunk://#diff-1423f21b09a0edce66dbaf1b78a9c2647b29085693a34e9d4d51c393b6505628L44-R53): Updated `infra` target to use the new Bicep parameters file and added `infra` to the `.PHONY` list. [[1]](diffhunk://#diff-1423f21b09a0edce66dbaf1b78a9c2647b29085693a34e9d4d51c393b6505628L44-R53) [[2]](diffhunk://#diff-1423f21b09a0edce66dbaf1b78a9c2647b29085693a34e9d4d51c393b6505628L70-R76)

### Documentation Enhancements:

* [`ocpp-server/README.md`](diffhunk://#diff-ab50e3edb4054e9e1b444d24c2e078076899ab569aeed21060201f31dc1db52bL14-R31): Replaced references to `main.parameters.json` with `main.parameters.bicepparam`. Added a new section for configuring Let's Encrypt with KeyVault and Azure DNS. Included an FAQ section to address common issues. [[1]](diffhunk://#diff-ab50e3edb4054e9e1b444d24c2e078076899ab569aeed21060201f31dc1db52bL14-R31) [[2]](diffhunk://#diff-ab50e3edb4054e9e1b444d24c2e078076899ab569aeed21060201f31dc1db52bR54-R97)

### Other Changes:

* [`ocpp-server/.gitignore`](diffhunk://#diff-104e43bb931f9667740d5fcd6f2ae8cacef49b37a1411d59ad0f4d9b5eee8dc2R400): Added `*parameters.bicepparam` to ignore list.
* [`ocpp-server/infra/main.parameters.bicepparam.example`](diffhunk://#diff-c7444a1b4bbd3931dac32750cf9c37f58b0dadec0601b42fd36f81c34cfd6198R1-R9): Added an example parameters file for Bicep.